### PR TITLE
Fixed comparison operator for emacs version.

### DIFF
--- a/zonokai.el
+++ b/zonokai.el
@@ -33,7 +33,7 @@
 (require 'dash)
 (require 'color)
 
-(unless (>= 24 emacs-major-version)
+(unless (<= 24 emacs-major-version)
   (error "The Zonokai theme requires Emacs 24 or later!"))
 
 (defgroup zonokai nil


### PR DESCRIPTION
This is correct comparison if you want to match emacs 24+. 